### PR TITLE
Add missing shebang to save-my-commit/setup.sh

### DIFF
--- a/save-my-commit/setup.sh
+++ b/save-my-commit/setup.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 kata="kata6-save-my-commit"
 
 # Include utils


### PR DESCRIPTION
setup.sh in save-my-commit/ misses the shebang line. In ZSH this causes a problem.
Added shebang line using /usr/bin/venv.